### PR TITLE
Handles missing mailbox settings gracefully

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 
 	"github.com/conductorone/baton-azure-infrastructure/pkg/connector/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -42,12 +46,16 @@ func (usr *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 	}
 
 	var userResources []*v2.Resource
+	l := ctxzap.Extract(ctx)
 
 	// GET https://graph.microsoft.com/beta/users/{userId}/mailboxSettings
 	for _, ur := range resp.Users {
 		mailboxSettingsResp, err := usr.client.UserMailboxSetting(ctx, ur.ID)
 		if err != nil {
-			// TODO: previous version was just log.Warn, should we return an error here?
+			if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+				l.Debug("UserMailboxSetting: user not found", zap.String("user_id", ur.ID), zap.Error(err))
+				continue
+			}
 			return nil, "", nil, err
 		}
 


### PR DESCRIPTION
I noticed Coastal Bank's Azure connector was still erroring after a previous fix was pushed and this code used to warn on error. The error on the dashboard is a 404, I am reverting to the previous behavior but only in case of 404

Prevents the connector from failing when fetching user mailbox settings fails due to the user not having a mailbox.

Logs a debug message instead of returning an error, allowing the connector to continue processing other users.
