### PR TITLE
add uhttp for storage account

### DIFF
--- a/pkg/connector/storage_account.go
+++ b/pkg/connector/storage_account.go
@@ -118,7 +118,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		client, err := armauthorization.NewRoleAssignmentsClient(
 			storageResourceIDs.subscriptionID,
 			usr.conn.token,
-			nil,
+			usr.conn.client.ArmOptions(),
 		)
 		if err != nil {
 			return nil, "", nil, err


### PR DESCRIPTION
#### Description

- [X] Bug fix
- [ ] New feature

Fix issue when storage account it's renamed during the sync, when storage account it's renamed after List call method, so the Grants method will receive an 404 because azure uses the name as ID.

Add uhttp to handle 404

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
