### PR TITLE
#BB-592 Add eligible permissions to storage accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more the proje
         - ServicePrincipalEndpoint.Read.All
         - User.Read
         - User.Read.All
+        - PrivilegedAccess.Read.AzureAD
+        - PrivilegedAccess.Read.AzureADGroup
+        - PrivilegedAccess.Read.AzureResources
     - Needs to add the application as Reader in the Azure Subscription that you want to sync
 - Then you will need to get the `tenant_id` of your Azure AD tenant. You can find this in the Azure Entra ID Overview
   page [here](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview).

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -3,7 +3,14 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"time"
 )
+
+type GraphResponse[T any] struct {
+	Context  string `json:"@odata.context"`
+	NextLink string `json:"@odata.nextLink"`
+	Value    T
+}
 
 type Manager struct {
 	Id          string `json:"id,omitempty"`
@@ -152,4 +159,41 @@ func (sp *ServicePrincipal) ExternalURL() string {
 			sp.ServicePrincipalType,
 		),
 	}).String()
+}
+
+type PMIPrivilegedAccessResource struct {
+	Id                 string     `json:"id"`
+	ExternalId         string     `json:"externalId"`
+	Type               string     `json:"type"`
+	DisplayName        string     `json:"displayName"`
+	Status             string     `json:"status"`
+	OnboardDateTime    *time.Time `json:"onboardDateTime"`
+	RegisteredDateTime *time.Time `json:"registeredDateTime"`
+}
+
+type PMIRoleAssigment struct {
+	Id                         string    `json:"id"`
+	ResourceId                 string    `json:"resourceId"`
+	RoleDefinitionId           string    `json:"roleDefinitionId"`
+	SubjectId                  string    `json:"subjectId"`
+	StartDateTime              time.Time `json:"startDateTime"`
+	EndDateTime                time.Time `json:"endDateTime"`
+	MemberType                 string    `json:"memberType"`
+	AssignmentState            string    `json:"assignmentState"`
+	Status                     string    `json:"status"`
+	RoleDefinitionOdataContext string    `json:"roleDefinition@odata.context"`
+	RoleDefinition             struct {
+		Id          string `json:"id"`
+		ResourceId  string `json:"resourceId"`
+		ExternalId  string `json:"externalId"`
+		TemplateId  string `json:"templateId"`
+		DisplayName string `json:"displayName"`
+		Type        string `json:"type"`
+	} `json:"roleDefinition"`
+	SubjectOdataContext string `json:"subject@odata.context"`
+	Subject             struct {
+		Id          string `json:"id"`
+		Type        string `json:"type"`
+		DisplayName string `json:"displayName"`
+	} `json:"subject"`
 }

--- a/pkg/connector/client/role_assignment.go
+++ b/pkg/connector/client/role_assignment.go
@@ -2,8 +2,13 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"path"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (a *AzureClient) GetRoleAssignments(
@@ -34,4 +39,50 @@ func (a *AzureClient) GetRoleAssignments(
 	}
 
 	return result, nil
+}
+
+func (a *AzureClient) GetPrivilegedAccessFromAzure(
+	ctx context.Context,
+	scope string,
+) (*PMIPrivilegedAccessResource, error) {
+	builder := a.QueryBuilder().
+		Version(Beta).
+		Add("$filter", fmt.Sprintf("externalId eq '%s'", scope))
+
+	reqURL := builder.BuildUrl("privilegedAccess", "azureResources", "resources")
+
+	var response GraphResponse[[]*PMIPrivilegedAccessResource]
+
+	err := a.requestWithToken(ctx, graphReadScopes, http.MethodGet, reqURL, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response.Value) == 0 {
+		return nil, status.New(codes.NotFound, fmt.Sprintf("resource not found for scope %s", scope)).Err()
+	}
+
+	return response.Value[0], nil
+}
+
+func (a *AzureClient) GetPrivilegedAccessRoleAssignments(ctx context.Context, pmiId string, nextLink string) ([]PMIRoleAssigment, string, error) {
+	builder := a.QueryBuilder().
+		Version(Beta).
+		Add("$expand", "roleDefinition,subject").
+		Add("$filter", fmt.Sprintf("(roleDefinition/resource/id eq '%s') and (assignmentState eq 'Eligible')", pmiId))
+
+	reqURL := builder.BuildUrlWithPagination(path.Join("privilegedAccess", "azureResources", "roleAssignments"), nextLink)
+
+	var response GraphResponse[[]PMIRoleAssigment]
+
+	err := a.requestWithToken(ctx, graphReadScopes, http.MethodGet, reqURL, nil, &response)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if len(response.Value) == 0 {
+		return nil, "", status.New(codes.NotFound, fmt.Sprintf("resource not found for pmi %s", pmiId)).Err()
+	}
+
+	return response.Value, response.NextLink, nil
 }

--- a/pkg/connector/helper.go
+++ b/pkg/connector/helper.go
@@ -929,3 +929,45 @@ func grantFromRole(
 		grantOpts...,
 	), nil
 }
+
+func grantFromEligibleAssignment(ctx context.Context, resource *v2.Resource, assigment client.PMIRoleAssigment) (*v2.Grant, error) {
+	l := ctxzap.Extract(ctx)
+
+	grantOpts := []grant.GrantOption{
+		grant.WithAnnotation(&v2.GrantImmutable{}),
+		grant.WithGrantMetadata(map[string]interface{}{
+			"displayName": assigment.RoleDefinition.DisplayName,
+		}),
+	}
+
+	var id *v2.ResourceId
+	switch assigment.Subject.Type {
+	case "User":
+		id = &v2.ResourceId{
+			Resource:     assigment.Subject.Id,
+			ResourceType: userResourceType.Id,
+		}
+	case "Group":
+		id = &v2.ResourceId{
+			Resource:     assigment.Subject.Id,
+			ResourceType: groupResourceType.Id,
+		}
+
+		grantOpts = append(grantOpts, grant.WithAnnotation(&v2.GrantExpandable{
+			EntitlementIds: []string{
+				fmt.Sprintf("group:%s:owners", assigment.Subject.Id),
+				fmt.Sprintf("group:%s:members", assigment.Subject.Id),
+			},
+		}))
+	default:
+		l.Error("unsupported principal type", zap.String("principalType", assigment.Subject.Type))
+		return nil, nil
+	}
+
+	return grant.NewGrant(
+		resource,
+		typeEligible,
+		id,
+		grantOpts...,
+	), nil
+}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -103,6 +103,13 @@ func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 	}
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, typeAssigned, options...))
 
+	options = []ent.EntitlementOption{
+		ent.WithDisplayName(fmt.Sprintf("%s Role Member", resource.DisplayName)),
+		ent.WithDescription(fmt.Sprintf("Member of %s role", resource.DisplayName)),
+		ent.WithGrantableTo(userResourceType, groupResourceType),
+	}
+	rv = append(rv, ent.NewAssignmentEntitlement(resource, typeAssigned, options...))
+
 	return rv, "", nil, nil
 }
 

--- a/pkg/connector/storage_account.go
+++ b/pkg/connector/storage_account.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/conductorone/baton-azure-infrastructure/pkg/connector/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/conductorone/baton-azure-infrastructure/pkg/connector/rolemapper"
@@ -13,6 +19,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
+
+var typeEligible = "eligible"
 
 type storageAccountBuilder struct {
 	conn *Connector
@@ -82,6 +90,14 @@ func (usr *storageAccountBuilder) Entitlements(_ context.Context, resource *v2.R
 		),
 	}
 
+	options := []entitlement.EntitlementOption{
+		entitlement.WithDisplayName(fmt.Sprintf("%s Eligible Member", resource.DisplayName)),
+		entitlement.WithDescription(fmt.Sprintf("Eligible for %s group", resource.DisplayName)),
+		entitlement.WithGrantableTo(userResourceType, groupResourceType),
+		entitlement.WithAnnotation(&v2.EntitlementImmutable{}),
+	}
+	rv = append(rv, entitlement.NewAssignmentEntitlement(resource, typeEligible, options...))
+
 	for _, value := range rolemapper.StorageAccountPermissions.Actions() {
 		ent := entitlement.NewPermissionEntitlement(
 			resource,
@@ -100,8 +116,16 @@ func (usr *storageAccountBuilder) Entitlements(_ context.Context, resource *v2.R
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
 func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	type bagState struct {
+		Value    string `json:"value"`
+		State    string `json:"state"`
+		NextLink string `json:"nextLink"`
+	}
+
+	l := ctxzap.Extract(ctx)
+
 	// Stores RoleDefinitionIds
-	bag := pagination.GenBag[string]{}
+	bag := pagination.GenBag[bagState]{}
 
 	err := bag.Unmarshal(pToken.Token)
 	if err != nil {
@@ -113,9 +137,13 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		return nil, "", nil, err
 	}
 
-	// Init state
 	if bag.Current() == nil {
-		client, err := armauthorization.NewRoleAssignmentsClient(
+		bag.Push(bagState{
+			Value: "",
+			State: "ELIGIBLE",
+		})
+
+		roleClient, err := armauthorization.NewRoleAssignmentsClient(
 			storageResourceIDs.subscriptionID,
 			usr.conn.token,
 			usr.conn.client.ArmOptions(),
@@ -126,7 +154,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 
 		var grants []*v2.Grant
 
-		rolesAssignments := client.NewListForScopePager(storageResourceIDs.AzureId(), nil)
+		rolesAssignments := roleClient.NewListForScopePager(storageResourceIDs.AzureId(), nil)
 
 		for rolesAssignments.More() {
 			result, err := rolesAssignments.NextPage(ctx)
@@ -135,7 +163,10 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 			}
 
 			convertErr, err := ConvertErr(result.Value, func(in *armauthorization.RoleAssignment) (*v2.Grant, error) {
-				bag.Push(StringValue(in.Properties.RoleDefinitionID))
+				bag.Push(bagState{
+					Value: StringValue(in.Properties.RoleDefinitionID),
+					State: "ASSIGNMENT",
+				})
 
 				return grantFromRoleAssigment(resource, "assignment", storageResourceIDs.subscriptionID, in)
 			})
@@ -158,40 +189,88 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 	// Get the current state
 	state := bag.Pop()
 
-	roleDefinitionId := StringValue(state)
-	roleDefinition, err := usr.conn.roleDefinitionsClient.GetByID(ctx, roleDefinitionId, nil)
-
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	actions, err := rolemapper.StorageAccountPermissions.MapRoleToAzureRoleAction(roleDefinition.Properties.Permissions)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
 	var grants []*v2.Grant
-	for _, action := range actions {
-		plainRoleId, err := roleIdFromRoleDefinitionId(roleDefinitionId)
-		if err != nil {
-			return nil, "", nil, err
-		}
 
-		roleResourceId, err := rs.NewResourceID(
-			roleResourceType,
-			fmt.Sprintf("%s:%s", plainRoleId, storageResourceIDs.subscriptionID),
-		)
+	switch state.State {
+	case "ASSIGNMENT":
+		roleDefinitionId := state.Value
+		roleDefinition, err := usr.conn.roleDefinitionsClient.GetByID(ctx, roleDefinitionId, nil)
 
 		if err != nil {
 			return nil, "", nil, err
 		}
 
-		newGrant, err := grantFromRole(resource, action, roleResourceId)
+		actions, err := rolemapper.StorageAccountPermissions.MapRoleToAzureRoleAction(roleDefinition.Properties.Permissions)
 		if err != nil {
 			return nil, "", nil, err
 		}
 
-		grants = append(grants, newGrant)
+		for _, action := range actions {
+			plainRoleId, err := roleIdFromRoleDefinitionId(roleDefinitionId)
+			if err != nil {
+				return nil, "", nil, err
+			}
+
+			roleResourceId, err := rs.NewResourceID(
+				roleResourceType,
+				fmt.Sprintf("%s:%s", plainRoleId, storageResourceIDs.subscriptionID),
+			)
+
+			if err != nil {
+				return nil, "", nil, err
+			}
+
+			newGrant, err := grantFromRole(resource, action, roleResourceId)
+			if err != nil {
+				return nil, "", nil, err
+			}
+
+			grants = append(grants, newGrant)
+		}
+	case "ELIGIBLE":
+		privilegedId := state.Value
+
+		if privilegedId == "" {
+			privilegedAccess, err := usr.conn.client.GetPrivilegedAccessFromAzure(ctx, storageResourceIDs.AzureId())
+			if err != nil {
+				if code, ok := status.FromError(err); ok && code.Code() == codes.NotFound {
+					l.Warn("Privileged access not found", zap.String("scope", storageResourceIDs.AzureId()))
+					return nil, "", nil, nil
+				}
+				return nil, "", nil, err
+			}
+
+			if privilegedAccess == nil {
+				return nil, "", nil, fmt.Errorf("privileged access not found for scope %s", storageResourceIDs.AzureId())
+			}
+
+			privilegedId = privilegedAccess.Id
+		}
+
+		privilegedAssignments, nextLink, err := usr.conn.client.GetPrivilegedAccessRoleAssignments(ctx, privilegedId, state.NextLink)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		grantsResponse, err := ConvertErr(privilegedAssignments, func(in client.PMIRoleAssigment) (*v2.Grant, error) {
+			return grantFromEligibleAssignment(ctx, resource, in)
+		})
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		if nextLink != "" {
+			bag.Push(bagState{
+				Value:    privilegedId,
+				State:    "ELIGIBLE",
+				NextLink: nextLink,
+			})
+		}
+
+		grants = append(grants, grantsResponse...)
+
+	default:
+		return nil, "", nil, fmt.Errorf("unknown state: %s", state.State)
 	}
 
 	nextToken, err := bag.Marshal()

--- a/pkg/connector/storage_account.go
+++ b/pkg/connector/storage_account.go
@@ -249,6 +249,10 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 
 		privilegedAssignments, nextLink, err := usr.conn.client.GetPrivilegedAccessRoleAssignments(ctx, privilegedId, state.NextLink)
 		if err != nil {
+			if status.Code(err) == codes.PermissionDenied {
+				l.Error("Permission denied", zap.String("scope", privilegedId))
+				return nil, "", nil, nil
+			}
 			return nil, "", nil, err
 		}
 

--- a/pkg/connector/storage_account.go
+++ b/pkg/connector/storage_account.go
@@ -233,10 +233,16 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		if privilegedId == "" {
 			privilegedAccess, err := usr.conn.client.GetPrivilegedAccessFromAzure(ctx, storageResourceIDs.AzureId())
 			if err != nil {
-				if code, ok := status.FromError(err); ok && code.Code() == codes.NotFound {
+				if status.Code(err) == codes.NotFound {
 					l.Warn("Privileged access not found", zap.String("scope", storageResourceIDs.AzureId()))
 					return nil, "", nil, nil
 				}
+
+				if status.Code(err) == codes.PermissionDenied {
+					l.Error("Permission denied for get privileged access", zap.String("scope", storageResourceIDs.AzureId()))
+					return nil, "", nil, nil
+				}
+
 				return nil, "", nil, err
 			}
 
@@ -250,7 +256,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		privilegedAssignments, nextLink, err := usr.conn.client.GetPrivilegedAccessRoleAssignments(ctx, privilegedId, state.NextLink)
 		if err != nil {
 			if status.Code(err) == codes.PermissionDenied {
-				l.Error("Permission denied", zap.String("scope", privilegedId))
+				l.Error("Permission denied for get privileged access roles", zap.String("scope", privilegedId))
 				return nil, "", nil, nil
 			}
 			return nil, "", nil, err


### PR DESCRIPTION
#### Description

- [ ] Bug fix
- [x] New feature

Add eligible entitlements for storage accounts to user and groups

Needs new permissions and access to the BETA api

        - PrivilegedAccess.Read.AzureAD
        - PrivilegedAccess.Read.AzureADGroup
        - PrivilegedAccess.Read.AzureResources


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
