### PR TITLE
[BB-903] better error messages for some azure requests

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -2,12 +2,15 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	zap "go.uber.org/zap"
 )
 
 var ValidHosts = []string{
@@ -84,6 +87,9 @@ func (a *AzureClient) doRequest(ctx context.Context,
 	var opts []uhttp.DoOption
 	if res != nil {
 		opts = append(opts, uhttp.WithResponse(res))
+		if graphErrResponse, ok := res.(*GraphResponse[any]); ok {
+			opts = append(opts, uhttp.WithErrorResponse(graphErrResponse))
+		}
 	}
 
 	resp, err := a.httpClient.Do(req, opts...)
@@ -104,6 +110,7 @@ func (a *AzureClient) requestWithToken(
 	body interface{},
 	res interface{},
 ) error {
+	l := ctxzap.Extract(ctx)
 	token, err := a.token.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: scopes,
 	})
@@ -113,6 +120,14 @@ func (a *AzureClient) requestWithToken(
 
 	err = a.doRequest(ctx, method, requestURL, token.Token, res, body)
 	if err != nil {
+		if res != nil {
+			if graphResponse, ok := res.(*GraphResponse[any]); ok {
+				if graphResponse.Error != nil {
+					l.Error("Error making request to Azure", zap.String("error", graphResponse.Error.Error()))
+					return fmt.Errorf("error making request to Azure (%s): %w", graphResponse.Error.Error(), err)
+				}
+			}
+		}
 		return err
 	}
 

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -10,6 +10,32 @@ type GraphResponse[T any] struct {
 	Context  string `json:"@odata.context"`
 	NextLink string `json:"@odata.nextLink"`
 	Value    T
+	Error    *GraphError `json:"error,omitempty"`
+}
+
+func (r *GraphResponse[any]) Message() string {
+	if r.Error != nil {
+		return r.Error.Error()
+	}
+	return ""
+}
+
+type GraphError struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	InnerError *struct {
+		Code      string `json:"code"`
+		RequestID string `json:"request-id"`
+		Date      string `json:"date"`
+	} `json:"innerError,omitempty"`
+	Details []struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"details,omitempty"`
+}
+
+func (e *GraphError) Error() string {
+	return fmt.Sprintf("code: %s, message: %s, innerError: %v, details: %v", e.Code, e.Message, e.InnerError, e.Details)
 }
 
 type Manager struct {


### PR DESCRIPTION
BB-903 is returning a 400, and based on the docs there should be a helpful error message and code but we aren't surfacing it right now. This is to try and surface it. This doesn't add error messages for all types of requests, just in particular for the type of `GetPrivilegedAccessFromAzure` request being made in this case.