### PR TITLE
refactor: upgrade all resource builders to ResourceSyncerV2 interface

### DIFF
--- a/cmd/baton-azure-infrastructure/main.go
+++ b/cmd/baton-azure-infrastructure/main.go
@@ -20,7 +20,7 @@ var version = "dev"
 func main() {
 	ctx := context.Background()
 	_, cmd, err := config.DefineConfiguration(ctx, "baton-azure-infrastructure", getConnector, cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.Connector{}),
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -65,8 +65,8 @@ type Connector struct {
 //     comma-separated list to restrict which builders are dispatched.
 //   - Pair-with-entra deployments deselect user/group/managed_identity via the
 //     c1 admin UI (or --sync-resource-types) rather than a bespoke connector flag.
-func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	syncers := []connectorbuilder.ResourceSyncer{
+func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	syncers := []connectorbuilder.ResourceSyncerV2{
 		newUserBuilder(d),
 		newGroupBuilder(d),
 		newManagedIdentityBuilder(d),

--- a/pkg/connector/container.go
+++ b/pkg/connector/container.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/conductorone/baton-azure-infrastructure/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -31,18 +30,18 @@ func (usr *containerBuilder) ResourceType(ctx context.Context) *v2.ResourceType 
 	return containerResourceType
 }
 
-func (usr *containerBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (usr *containerBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
 	if parentResourceID.ResourceType != storageAccountResourceType.Id {
-		return nil, "", nil, fmt.Errorf("invalid resource type: %s", parentResourceID.ResourceType)
+		return nil, nil, fmt.Errorf("invalid resource type: %s", parentResourceID.ResourceType)
 	}
 
 	storageId, err := newStorageResourceSplitIdDataFromConnectorId(parentResourceID.Resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	factory, err := armstorage.NewClientFactory(
@@ -52,7 +51,7 @@ func (usr *containerBuilder) List(ctx context.Context, parentResourceID *v2.Reso
 	)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	pager := factory.NewBlobContainersClient().
@@ -67,7 +66,7 @@ func (usr *containerBuilder) List(ctx context.Context, parentResourceID *v2.Reso
 	for pager.More() {
 		result, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		temp, err := ConvertErr(result.Value, func(container *armstorage.ListContainerItem) (*v2.Resource, error) {
@@ -95,17 +94,17 @@ func (usr *containerBuilder) List(ctx context.Context, parentResourceID *v2.Reso
 		})
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		resources = append(resources, temp...)
 	}
 
-	return resources, "", nil, nil
+	return resources, nil, nil
 }
 
 // Entitlements always returns an empty slice for users.
-func (usr *containerBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (usr *containerBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	rv := []*v2.Entitlement{
 		entitlement.NewPermissionEntitlement(
 			resource,
@@ -130,7 +129,7 @@ func (usr *containerBuilder) Entitlements(_ context.Context, resource *v2.Resour
 		rv = append(rv, ent)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
 func (usr *containerBuilder) getRoleDefinition(ctx context.Context, roleDefinitionId string) (armauthorization.RoleDefinitionsClientGetByIDResponse, error) {
@@ -155,28 +154,28 @@ func (usr *containerBuilder) getRoleDefinition(ctx context.Context, roleDefiniti
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	if resource.ParentResourceId == nil || resource.ParentResourceId.ResourceType != storageAccountResourceType.Id {
-		return nil, "", nil, fmt.Errorf("container resource must have a parent resource from type %s", storageAccountResourceType.Id)
+		return nil, nil, fmt.Errorf("container resource must have a parent resource from type %s", storageAccountResourceType.Id)
 	}
 
 	// RoleDefinitionsIds
 	bag := pagination.GenBag[string]{}
 
-	err := bag.Unmarshal(pToken.Token)
+	err := bag.Unmarshal(opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	parsedParentId, err := newStorageResourceSplitIdDataFromConnectorId(resource.ParentResourceId.Resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	if bag.Current() == nil {
 		idSplit := strings.Split(resource.Id.Resource, ":")
 		if len(idSplit) != 2 {
-			return nil, "", nil, fmt.Errorf("invalid resource id: %s", resource.Id.Resource)
+			return nil, nil, fmt.Errorf("invalid resource id: %s", resource.Id.Resource)
 		}
 
 		containerName := idSplit[1]
@@ -184,7 +183,7 @@ func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, 
 		scope := fmt.Sprintf("%s/blobServices/default/containers/%s", parsedParentId.AzureId(), containerName)
 		assignments, err := usr.client.GetRoleAssignments(ctx, parsedParentId.subscriptionID, scope)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		grants, err := ConvertErr(assignments, func(in *armauthorization.RoleAssignment) (*v2.Grant, error) {
@@ -198,15 +197,15 @@ func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, 
 			)
 		})
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		nextToken, err := bag.Marshal()
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		return grants, nextToken, nil, nil
+		return grants, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 	}
 
 	state := bag.Pop()
@@ -214,19 +213,19 @@ func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, 
 	roleDefinitionId := StringValue(state)
 	roleDefinition, err := usr.getRoleDefinition(ctx, roleDefinitionId)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	actions, err := rolemapper.ContainerPermissions.MapRoleToAzureRoleAction(roleDefinition.Properties.Permissions)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var grants []*v2.Grant
 	for _, action := range actions {
 		plainRoleId, err := roleIdFromRoleDefinitionId(roleDefinitionId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		roleResourceId, err := rs.NewResourceID(
@@ -235,12 +234,12 @@ func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, 
 		)
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		newGrant, err := grantFromRole(resource, action, roleResourceId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		grants = append(grants, newGrant)
@@ -248,10 +247,10 @@ func (usr *containerBuilder) Grants(ctx context.Context, resource *v2.Resource, 
 
 	nextToken, err := bag.Marshal()
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	return grants, nextToken, nil, nil
+	return grants, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 func newContainerBuilder(conn *Connector) *containerBuilder {

--- a/pkg/connector/enterprise_applications.go
+++ b/pkg/connector/enterprise_applications.go
@@ -18,6 +18,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
@@ -41,17 +42,17 @@ func (e *enterpriseApplicationsBuilder) ResourceType(ctx context.Context) *v2.Re
 	return enterpriseApplicationResourceType
 }
 
-func (e *enterpriseApplicationsBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: userResourceType.Id})
+func (e *enterpriseApplicationsBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: userResourceType.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	reqURL := bag.PageToken()
 
 	resp, err := e.client.ListServicePrincipals(ctx, reqURL)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var applicationsOwned []*client.ServicePrincipal
@@ -68,7 +69,7 @@ func (e *enterpriseApplicationsBuilder) List(ctx context.Context, parentResource
 	for i, app := range applicationsOwned {
 		value, err := enterpriseApplicationResource(ctx, app, parentResourceID)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		resources[i] = value
@@ -76,13 +77,13 @@ func (e *enterpriseApplicationsBuilder) List(ctx context.Context, parentResource
 
 	pageToken, err := bag.NextToken(resp.NextLink)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	return resources, pageToken, nil, nil
+	return resources, &rs.SyncOpResults{NextPageToken: pageToken}, nil
 }
 
-func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var err error
 
 	// https://learn.microsoft.com/en-us/graph/api/resources/approleassignment?view=graph-rest-1.0
@@ -95,7 +96,7 @@ func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resour
 
 		ownersEntIdString, err := ownersEntId.MarshalString()
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		ent := entitlement.NewPermissionEntitlement(
@@ -125,7 +126,7 @@ func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resour
 
 		defaultAppRoleAssignmentStringerString, err := defaultAppRoleAssignmentStringer.MarshalString()
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		ent := entitlement.NewAssignmentEntitlement(
@@ -145,7 +146,7 @@ func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resour
 	})
 
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: failed to get service principal on cache: %w", err)
+		return nil, nil, fmt.Errorf("baton-azure-infrastructure: failed to get service principal on cache: %w", err)
 	}
 
 	for _, appRole := range servicePrincipal.AppRoles {
@@ -165,7 +166,7 @@ func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resour
 
 		appRoleAssignmentIdString, err := appRoleAssignmentId.MarshalString()
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		ent := entitlement.NewAssignmentEntitlement(
@@ -180,16 +181,16 @@ func (e *enterpriseApplicationsBuilder) Entitlements(ctx context.Context, resour
 		rv = append(rv, ent)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (e *enterpriseApplicationsBuilder) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (e *enterpriseApplicationsBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 
 	b := &pagination.Bag{}
-	err := b.Unmarshal(pt.Token)
+	err := b.Unmarshal(opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// AzureId relarted to Azure resource
@@ -222,7 +223,7 @@ func (e *enterpriseApplicationsBuilder) Grants(ctx context.Context, resource *v2
 			return e.client.ServicePrincipal(ctx, principalId)
 		})
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		resp := principalResp.AppRolesAssignedTo
@@ -262,16 +263,16 @@ func (e *enterpriseApplicationsBuilder) Grants(ctx context.Context, resource *v2
 			), nil
 		})
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		b.Pop()
 		nextToken, err := b.Marshal()
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		return grants, nextToken, nil, err
+		return grants, &rs.SyncOpResults{NextPageToken: nextToken}, err
 	case ownersStr:
 		resp, err := e.client.ServicePrincipalOwners(ctx, principalId)
 		if err != nil {
@@ -282,10 +283,10 @@ func (e *enterpriseApplicationsBuilder) Grants(ctx context.Context, resource *v2
 					zap.String("url", ps.Token),
 					zap.Error(err),
 				)
-				return nil, "", nil, nil
+				return nil, nil, nil
 			}
 
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		grants, err := ConvertErr(resp.Members, func(gm *client.Membership) (*v2.Grant, error) {
@@ -323,17 +324,17 @@ func (e *enterpriseApplicationsBuilder) Grants(ctx context.Context, resource *v2
 			), nil
 		})
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		pageToken, err := b.NextToken(resp.NextLink)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		return grants, pageToken, nil, nil
+		return grants, &rs.SyncOpResults{NextPageToken: pageToken}, nil
 	default:
-		return nil, "", nil, fmt.Errorf("unknown resource type: %s", ps.ResourceTypeID)
+		return nil, nil, fmt.Errorf("unknown resource type: %s", ps.ResourceTypeID)
 	}
 }
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	zap "go.uber.org/zap"
 )
@@ -40,24 +41,24 @@ func (g *groupBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return groupResourceType
 }
 
-func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	resp, err := g.client.Groups(ctx, pToken.Token)
+func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	resp, err := g.client.Groups(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	groups, err := ConvertErr(resp.Groups, func(g *client.Group) (*v2.Resource, error) {
 		return groupResource(ctx, g, parentResourceID)
 	})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	return groups, resp.NextLink, nil, nil
+	return groups, &rs.SyncOpResults{NextPageToken: resp.NextLink}, nil
 }
 
 // Entitlements always returns an empty slice for users.
-func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 	options := []ent.EntitlementOption{
 		ent.WithDisplayName(fmt.Sprintf("%s Group Owner", resource.DisplayName)),
@@ -73,15 +74,15 @@ func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 	}
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, typeMembers, options...))
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 	b := &pagination.Bag{}
-	err := b.Unmarshal(pToken.Token)
+	err := b.Unmarshal(opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// NOTE: We use the Beta URL here because in the v1.0 docs there is this note (last checked December 2024)
@@ -107,7 +108,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 
 	ps := b.Pop()
 	if ps == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
 	groupId := resource.Id.Resource
@@ -119,7 +120,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	case typeMembers:
 		memberShip, err = g.client.GroupMembers(ctx, groupId, ps.Token)
 	default:
-		return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: unknown resource type ID %s", ps.ResourceTypeID)
+		return nil, nil, fmt.Errorf("baton-azure-infrastructure: unknown resource type ID %s", ps.ResourceTypeID)
 	}
 
 	if err != nil {
@@ -130,10 +131,10 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 				zap.String("group_id", groupId),
 				zap.Error(err),
 			)
-			return nil, "", nil, nil
+			return nil, nil, nil
 		}
 
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// dubious hack: if we get less than 50 members,
@@ -154,15 +155,15 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 
 	grants, err := getGroupGrants(ctx, memberShip, resource, ps)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	nextToken, err := b.Marshal()
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	return grants, nextToken, nil, nil
+	return grants, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 func (g *groupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {

--- a/pkg/connector/internal_integration_test.go
+++ b/pkg/connector/internal_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -70,7 +69,7 @@ func TestUserBuilderList(t *testing.T) {
 	require.NoError(t, err)
 
 	u := newUserBuilder(connTest)
-	res, _, _, err := u.List(ctxTest, nil, &pagination.Token{})
+	res, _, err := u.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
@@ -84,7 +83,7 @@ func TestGroupBuilderList(t *testing.T) {
 	require.NoError(t, err)
 
 	u := newGroupBuilder(connTest)
-	res, _, _, err := u.List(ctxTest, nil, &pagination.Token{})
+	res, _, err := u.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
@@ -120,7 +119,7 @@ func TestSubscriptionBuilderList(t *testing.T) {
 	require.NoError(t, err)
 
 	s := newSubscriptionBuilder(connTest)
-	_, _, _, err = s.List(ctxTest, nil, &pagination.Token{})
+	_, _, err = s.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 }
 
@@ -133,7 +132,7 @@ func TestTenantBuilderList(t *testing.T) {
 	require.NoError(t, err)
 
 	tn := newTenantBuilder(connTest)
-	_, _, _, err = tn.List(ctxTest, nil, &pagination.Token{})
+	_, _, err = tn.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 }
 
@@ -146,7 +145,7 @@ func TestResourceGroupBuilderList(t *testing.T) {
 	require.NoError(t, err)
 
 	rg := newResourceGroupBuilder(connTest)
-	_, _, _, err = rg.List(ctxTest, nil, &pagination.Token{})
+	_, _, err = rg.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 }
 
@@ -159,7 +158,7 @@ func TestRoleAssignmentResourceGroupBuilderList(t *testing.T) {
 	require.NoError(t, err)
 
 	ra := newRoleAssignmentResourceGroupBuilder(connTest)
-	_, _, _, err = ra.List(ctxTest, nil, &pagination.Token{})
+	_, _, err = ra.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 }
 func TestRoleBuilderList(t *testing.T) {
@@ -173,7 +172,7 @@ func TestRoleBuilderList(t *testing.T) {
 	connTest.SkipUnusedRoles = true
 
 	r := newRoleBuilder(connTest)
-	_, _, _, err = r.List(ctxTest, nil, &pagination.Token{})
+	_, _, err = r.List(ctxTest, nil, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 }
 
@@ -202,7 +201,7 @@ func TestRoleGrants(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 
-		_, _, _, err = r.Grants(ctxTest, resource, nil)
+		_, _, err = r.Grants(ctxTest, resource, rs.SyncOpAttrs{})
 		require.NoError(t, err)
 	}
 }
@@ -229,7 +228,7 @@ func TestRoleAssignmentResourceGroupGrants(t *testing.T) {
 			}, nil)
 		require.NoError(t, err)
 
-		_, _, _, err = r.Grants(ctxTest, gr, nil)
+		_, _, err = r.Grants(ctxTest, gr, rs.SyncOpAttrs{})
 		require.NoError(t, err)
 	}
 }
@@ -250,7 +249,7 @@ func TestSubscriptionGrants(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _, _, err = s.Grants(ctxTest, res, &pagination.Token{})
+	_, _, err = s.Grants(ctxTest, res, rs.SyncOpAttrs{})
 	require.NoError(t, err)
 }
 
@@ -485,7 +484,7 @@ func TestResourceGroupEntitlements(t *testing.T) {
 			}, nil)
 		require.NoError(t, err)
 
-		_, _, _, err = rg.Entitlements(ctxTest, assignmentResourceGroupResource, nil)
+		_, _, err = rg.Entitlements(ctxTest, assignmentResourceGroupResource, rs.SyncOpAttrs{})
 		require.NoError(t, err)
 	}
 }

--- a/pkg/connector/managed_identities.go
+++ b/pkg/connector/managed_identities.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/conductorone/baton-azure-infrastructure/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type managedIdentityBuilder struct {
@@ -17,30 +16,30 @@ func (m *managedIdentityBuilder) ResourceType(ctx context.Context) *v2.ResourceT
 	return managedIdentitylResourceType
 }
 
-func (m *managedIdentityBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	resp, err := m.client.ListServicePrincipalsManagedIdentity(ctx, pt.Token)
+func (m *managedIdentityBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	resp, err := m.client.ListServicePrincipalsManagedIdentity(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	users, err := ConvertErr(resp.Value, func(mi *client.ServicePrincipal) (*v2.Resource, error) {
 		return managedIdentityResource(ctx, mi, parentResourceID)
 	})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	return users, resp.NextLink, nil, nil
+	return users, &rs.SyncOpResults{NextPageToken: resp.NextLink}, nil
 }
 
 // Entitlements always returns an empty slice for managed identities.
-func (m *managedIdentityBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (m *managedIdentityBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for managed identities since they don't have any entitlements.
-func (m *managedIdentityBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (m *managedIdentityBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newManagedIdentityBuilder(c *Connector) *managedIdentityBuilder {

--- a/pkg/connector/management_group.go
+++ b/pkg/connector/management_group.go
@@ -10,8 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -41,17 +39,17 @@ func (b *managementGroupBuilder) ResourceType(_ context.Context) *v2.ResourceTyp
 	return managementGroupResourceType
 }
 
-func (b *managementGroupBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (b *managementGroupBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	// Hard-require the hierarchy: management-group resources must carry parent
 	// wiring for c1's tree UX to render them correctly. Fail fast here if the
 	// SP lacks Management Group Reader. See hierarchy.go for the shared memo.
 	if err := b.conn.ensureHierarchy(ctx); err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	mgs, err := b.conn.managementGroups(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: listing management groups: %w", err)
+		return nil, nil, fmt.Errorf("baton-azure-infrastructure: listing management groups: %w", err)
 	}
 
 	// One-shot tenant-hierarchy load so managementGroupResource can set
@@ -65,21 +63,21 @@ func (b *managementGroupBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *
 	for _, mg := range mgs {
 		resource, err := managementGroupResource(mg, idx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		if resource != nil {
 			rv = append(rv, resource)
 		}
 	}
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (b *managementGroupBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (b *managementGroupBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
-func (b *managementGroupBuilder) Grants(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (b *managementGroupBuilder) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // managementGroupResource builds a baton resource for an Azure management group.

--- a/pkg/connector/resource_group.go
+++ b/pkg/connector/resource_group.go
@@ -5,8 +5,7 @@ import (
 
 	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type resourceGroupBuilder struct {
@@ -17,9 +16,9 @@ func (rg *resourceGroupBuilder) ResourceType(ctx context.Context) *v2.ResourceTy
 	return resourceGroupResourceType
 }
 
-func (rg *resourceGroupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (rg *resourceGroupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
 	var rv []*v2.Resource
@@ -31,13 +30,13 @@ func (rg *resourceGroupBuilder) List(ctx context.Context, parentResourceID *v2.R
 		rg.conn.client.ArmOptions(),
 	)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for pager := client.NewListPager(nil); pager.More(); {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		// NOTE: The service desides how many items to return on a page.
@@ -52,22 +51,22 @@ func (rg *resourceGroupBuilder) List(ctx context.Context, parentResourceID *v2.R
 					Resource:     StringValue(&subscriptionID),
 				})
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			rv = append(rv, gr)
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (rg *resourceGroupBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (rg *resourceGroupBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
-func (rg *resourceGroupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (rg *resourceGroupBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newResourceGroupBuilder(c *Connector) *resourceGroupBuilder {

--- a/pkg/connector/resource_group_role_assignment.go
+++ b/pkg/connector/resource_group_role_assignment.go
@@ -12,9 +12,9 @@ import (
 	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	uuid "github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -36,30 +36,30 @@ func (ra *roleAssignmentResourceGroupBuilder) ResourceType(ctx context.Context) 
 	return roleAssignmentResourceGroupType
 }
 
-func (ra *roleAssignmentResourceGroupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (ra *roleAssignmentResourceGroupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var rv []*v2.Resource
 	pagerSubscriptions := ra.conn.clientFactory.NewSubscriptionsClient().NewListPager(nil)
 	for pagerSubscriptions.More() {
 		page, err := pagerSubscriptions.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		for _, subscription := range page.Value {
 			lstRoles, err := getAllRoles(ctx, ra.conn, *subscription.SubscriptionID)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			client, err := armresources.NewResourceGroupsClient(*subscription.SubscriptionID, ra.conn.token, ra.conn.client.ArmOptions())
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			for pager := client.NewListPager(nil); pager.More(); {
 				page, err := pager.NextPage(ctx)
 				if err != nil {
-					return nil, "", nil, err
+					return nil, nil, err
 				}
 
 				// NOTE: The service decides how many items to return on a page.
@@ -77,7 +77,7 @@ func (ra *roleAssignmentResourceGroupBuilder) List(ctx context.Context, parentRe
 								Resource:     StringValue(subscription.SubscriptionID),
 							})
 						if err != nil {
-							return nil, "", nil, err
+							return nil, nil, err
 						}
 
 						rv = append(rv, gr)
@@ -87,10 +87,10 @@ func (ra *roleAssignmentResourceGroupBuilder) List(ctx context.Context, parentRe
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (ra *roleAssignmentResourceGroupBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (ra *roleAssignmentResourceGroupBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 	options := []ent.EntitlementOption{
 		ent.WithDisplayName(fmt.Sprintf("%s Resource Group Owner", resource.DisplayName)),
@@ -106,10 +106,10 @@ func (ra *roleAssignmentResourceGroupBuilder) Entitlements(ctx context.Context, 
 	}
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, typeAssigned, options...))
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (ra *roleAssignmentResourceGroupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (ra *roleAssignmentResourceGroupBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var (
 		rv                                        []*v2.Grant
 		gr                                        *v2.Grant
@@ -126,7 +126,7 @@ func (ra *roleAssignmentResourceGroupBuilder) Grants(ctx context.Context, resour
 	// Create a Role Assignments Client
 	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, ra.conn.token, ra.conn.client.ArmOptions())
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroupName)
@@ -136,7 +136,7 @@ func (ra *roleAssignmentResourceGroupBuilder) Grants(ctx context.Context, resour
 	for pagerResourceGroup.More() {
 		page, err := pagerResourceGroup.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		for _, roleAssignment := range page.Value {
@@ -156,7 +156,7 @@ func (ra *roleAssignmentResourceGroupBuilder) Grants(ctx context.Context, resour
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
 func (ra *roleAssignmentResourceGroupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -9,9 +9,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -33,9 +33,9 @@ func (r *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return roleResourceType
 }
 
-func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 	var rv []*v2.Resource
 	subscriptionID := parentResourceID.Resource
@@ -46,7 +46,7 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 	for pagerRoles.More() {
 		resp, err := pagerRoles.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		// Iterate over role definitions
@@ -58,7 +58,7 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 
 				err := r.cacheRoleAssignments(ctx, subscriptionID)
 				if err != nil {
-					return nil, "", nil, err
+					return nil, nil, err
 				}
 				// omit ok since we know the key exists
 				assignments, _ := r.cache.Get(subscriptionID)
@@ -69,22 +69,22 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 				}
 			}
 
-			rs, err := roleResource(ctx, role, &v2.ResourceId{
+			rsrc, err := roleResource(ctx, role, &v2.ResourceId{
 				ResourceType: subscriptionsResourceType.Id,
 				Resource:     StringValue(&subscriptionID),
 			})
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
-			rv = append(rv, rs)
+			rv = append(rv, rsrc)
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 	options := []ent.EntitlementOption{
 		ent.WithDisplayName(fmt.Sprintf("%s Role Owner", resource.DisplayName)),
@@ -100,10 +100,10 @@ func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 	}
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, typeAssigned, options...))
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var (
 		subscriptionID, roleID string
 		rv                     []*v2.Grant
@@ -118,7 +118,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 
 	err := r.cacheRoleAssignments(ctx, subscriptionID)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	assignments, _ := r.cache.Get(subscriptionID)
@@ -137,7 +137,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 		gr = grant.NewGrant(resource, typeAssigned, principalId)
 		rv = append(rv, gr)
 	}
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
 func (r *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {

--- a/pkg/connector/role_assignment.go
+++ b/pkg/connector/role_assignment.go
@@ -170,12 +170,12 @@ type raBagState struct {
 //	returns empty + no error — List continues with stage-1 coverage
 //	only. Per-sub 403s are logged and skipped (common in mixed-
 //	permission enterprise tenants).
-func (b *roleAssignmentBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (b *roleAssignmentBuilder) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 
-	bag, err := pagination.GenBagFromToken[raBagState](pToken)
+	bag, err := pagination.GenBagFromToken[raBagState](&opts.PageToken)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: role_assignment pagination: %w", err)
+		return nil, nil, fmt.Errorf("baton-azure-infrastructure: role_assignment pagination: %w", err)
 	}
 
 	// First-call seed: kick off with the init phase.
@@ -191,14 +191,14 @@ func (b *roleAssignmentBuilder) List(ctx context.Context, _ *v2.ResourceId, pTok
 	case raPhaseSub:
 		return b.listSubPage(ctx, l, bag, state)
 	default:
-		return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: role_assignment pagination: unknown phase %q", state.Phase)
+		return nil, nil, fmt.Errorf("baton-azure-infrastructure: role_assignment pagination: unknown phase %q", state.Phase)
 	}
 }
 
 // listInit handles the first pagination call: enumerate subscriptions,
 // emit every mgmt-group-scope assignment in a single page, and seed the
 // bag with the pending-sub list + the mgmt-group-scope seen-set.
-func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag *pagination.GenBag[raBagState]) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag *pagination.GenBag[raBagState]) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	// Management Group Reader is a hard prerequisite: without the tenant
 	// hierarchy the scope-parent wiring produces disconnected roots and the
 	// sparse-ACL tree UX renders poorly. The sync.Once memoization means
@@ -208,7 +208,7 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 	// phase error path doesn't need a live Connector — keeps pagination-
 	// parsing unit tests working with a bare builder. See hierarchy.go.
 	if err := b.conn.ensureHierarchy(ctx); err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// Enumerate subscriptions (IDs only; we walk each one in its own page
@@ -217,11 +217,11 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 	var pendingSubs []string
 	for subsPager.More() {
 		if err := ctx.Err(); err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		subsPage, err := subsPager.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: listing subscriptions: %w", err)
+			return nil, nil, fmt.Errorf("baton-azure-infrastructure: listing subscriptions: %w", err)
 		}
 		for _, sub := range subsPage.Value {
 			if sub == nil || sub.SubscriptionID == nil || *sub.SubscriptionID == "" {
@@ -242,16 +242,16 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 	if firstSubID != "" {
 		mgs, err := b.conn.managementGroups(ctx)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: listing management groups: %w", err)
+			return nil, nil, fmt.Errorf("baton-azure-infrastructure: listing management groups: %w", err)
 		}
 		if len(mgs) > 0 {
 			raClient, err := armauthorization.NewRoleAssignmentsClient(firstSubID, b.conn.token, b.conn.client.ArmOptions())
 			if err != nil {
-				return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: role assignments client for mgmt-group walk: %w", err)
+				return nil, nil, fmt.Errorf("baton-azure-infrastructure: role assignments client for mgmt-group walk: %w", err)
 			}
 			for _, mg := range mgs {
 				if err := ctx.Err(); err != nil {
-					return nil, "", nil, err
+					return nil, nil, err
 				}
 				if mg == nil || mg.ID == nil {
 					continue
@@ -260,7 +260,7 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 				pager := raClient.NewListForScopePager(mgScope, nil)
 				for pager.More() {
 					if err := ctx.Err(); err != nil {
-						return nil, "", nil, err
+						return nil, nil, err
 					}
 					page, pagerErr := pager.NextPage(ctx)
 					if pagerErr != nil {
@@ -272,7 +272,7 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 								zap.String("mgScope", mgScope), zap.Error(pagerErr))
 							break
 						}
-						return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: listing role assignments at mgmt-group %s: %w", mgScope, pagerErr)
+						return nil, nil, fmt.Errorf("baton-azure-infrastructure: listing role assignments at mgmt-group %s: %w", mgScope, pagerErr)
 					}
 					for _, ra := range page.Value {
 						if ra == nil || ra.Properties == nil || ra.Name == nil {
@@ -280,7 +280,7 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 						}
 						resource, resErr := roleAssignmentResource(firstSubID, ra)
 						if resErr != nil {
-							return nil, "", nil, resErr
+							return nil, nil, resErr
 						}
 						if resource == nil {
 							continue
@@ -312,7 +312,7 @@ func (b *roleAssignmentBuilder) listInit(ctx context.Context, l *zap.Logger, bag
 // process one whole sub per baton call rather than one Azure page),
 // dedup against the mgmt-group-scope seen-set, then advance to the next
 // pending sub.
-func (b *roleAssignmentBuilder) listSubPage(ctx context.Context, l *zap.Logger, bag *pagination.GenBag[raBagState], state *raBagState) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (b *roleAssignmentBuilder) listSubPage(ctx context.Context, l *zap.Logger, bag *pagination.GenBag[raBagState], state *raBagState) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	subID := state.CurrentSub
 	seen := make(map[string]struct{}, len(state.SeenAssignmentNames))
 	for _, n := range state.SeenAssignmentNames {
@@ -323,13 +323,13 @@ func (b *roleAssignmentBuilder) listSubPage(ctx context.Context, l *zap.Logger, 
 	if subID != "" {
 		raClient, err := armauthorization.NewRoleAssignmentsClient(subID, b.conn.token, b.conn.client.ArmOptions())
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: role assignments client: %w", err)
+			return nil, nil, fmt.Errorf("baton-azure-infrastructure: role assignments client: %w", err)
 		}
 		pager := raClient.NewListForSubscriptionPager(nil)
 	subPager:
 		for pager.More() {
 			if err := ctx.Err(); err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 			page, pagerErr := pager.NextPage(ctx)
 			if pagerErr != nil {
@@ -340,7 +340,7 @@ func (b *roleAssignmentBuilder) listSubPage(ctx context.Context, l *zap.Logger, 
 						zap.String("subID", subID), zap.Error(pagerErr))
 					break subPager
 				}
-				return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: listing role assignments for sub %s: %w", subID, pagerErr)
+				return nil, nil, fmt.Errorf("baton-azure-infrastructure: listing role assignments for sub %s: %w", subID, pagerErr)
 			}
 			for _, ra := range page.Value {
 				if !shouldEmitRoleAssignment(ra, seen) {
@@ -348,7 +348,7 @@ func (b *roleAssignmentBuilder) listSubPage(ctx context.Context, l *zap.Logger, 
 				}
 				resource, resErr := roleAssignmentResource(subID, ra)
 				if resErr != nil {
-					return nil, "", nil, resErr
+					return nil, nil, resErr
 				}
 				if resource == nil {
 					// Unlike the seen-set short-circuit, roleAssignmentResource
@@ -415,10 +415,10 @@ func advancePendingSubs(justProcessed string, pending []string) (string, []strin
 
 // finishPage serializes the bag and returns the (resources, nextToken,
 // annotations, error) tuple in the shape List expects.
-func finishPage(bag *pagination.GenBag[raBagState], emitted []*v2.Resource) ([]*v2.Resource, string, annotations.Annotations, error) {
+func finishPage(bag *pagination.GenBag[raBagState], emitted []*v2.Resource) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	nextToken, err := bag.Marshal()
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-azure-infrastructure: role_assignment pagination marshal: %w", err)
+		return nil, nil, fmt.Errorf("baton-azure-infrastructure: role_assignment pagination marshal: %w", err)
 	}
 	// When the bag is fully drained Marshal returns a non-empty
 	// empty-states envelope; the SDK's end-of-pagination signal is an
@@ -426,10 +426,10 @@ func finishPage(bag *pagination.GenBag[raBagState], emitted []*v2.Resource) ([]*
 	if bag.Current() == nil {
 		nextToken = ""
 	}
-	return emitted, nextToken, nil, nil
+	return emitted, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
-func (b *roleAssignmentBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (b *roleAssignmentBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	return []*v2.Entitlement{
 		ent.NewAssignmentEntitlement(
 			resource,
@@ -443,7 +443,7 @@ func (b *roleAssignmentBuilder) Entitlements(_ context.Context, resource *v2.Res
 			// confusing error.
 			ent.WithGrantableTo(userResourceType, managedIdentitylResourceType, enterpriseApplicationResourceType),
 		),
-	}, "", nil, nil
+	}, nil, nil
 }
 
 // batonToAzurePrincipalType maps a baton principal resource-type id to the
@@ -469,10 +469,10 @@ func batonToAzurePrincipalType(batonResourceType string) *armauthorization.Princ
 // We resolve principal type via the per-builder cache (backed by
 // getPrincipalType, which hits Graph directoryObjects) so that repeat
 // principals across many bindings don't each incur a Graph roundtrip.
-func (b *roleAssignmentBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (b *roleAssignmentBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	principalID, parsedOK := parsePrincipalFromRoleAssignmentResourceID(resource.Id.Resource)
 	if !parsedOK || principalID == "" {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 	principalType := b.principalTypeForID(ctx, principalID)
 	if principalType == "" {
@@ -480,7 +480,7 @@ func (b *roleAssignmentBuilder) Grants(ctx context.Context, resource *v2.Resourc
 		// principalTypeForID). Emit no grant rather than failing the whole
 		// sync — matches the degrade-gracefully pattern used elsewhere in
 		// this connector.
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 	principalResourceType := mapGraphPrincipalTypeToBaton(principalType)
 	if principalResourceType == "" {
@@ -494,14 +494,14 @@ func (b *roleAssignmentBuilder) Grants(ctx context.Context, resource *v2.Resourc
 			zap.String("principal_id", principalID),
 			zap.String("role_assignment_resource_id", resource.Id.Resource),
 		)
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 	principalResourceID := &v2.ResourceId{
 		ResourceType: principalResourceType,
 		Resource:     principalID,
 	}
 	gr := grant.NewGrant(resource, typeAssigned, principalResourceID)
-	return []*v2.Grant{gr}, "", nil, nil
+	return []*v2.Grant{gr}, nil, nil
 }
 
 // Grant attaches a principal to an existing role_assignment binding by creating

--- a/pkg/connector/role_assignment_test.go
+++ b/pkg/connector/role_assignment_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -584,15 +585,19 @@ func TestFinishPageEmptyBagYieldsEmptyToken(t *testing.T) {
 	bag.Push(raBagState{Phase: raPhaseSub, CurrentSub: "x"})
 	_ = bag.Pop()
 
-	resources, tok, anns, err := finishPage(bag, nil)
+	resources, res, err := finishPage(bag, nil)
 	if err != nil {
 		t.Fatalf("finishPage: %v", err)
 	}
-	if anns != nil {
-		t.Errorf("expected nil annotations, got %v", anns)
+	if res != nil && res.Annotations != nil {
+		t.Errorf("expected nil annotations, got %v", res.Annotations)
 	}
 	if len(resources) != 0 {
 		t.Errorf("expected no resources, got %d", len(resources))
+	}
+	tok := ""
+	if res != nil {
+		tok = res.NextPageToken
 	}
 	if tok != "" {
 		t.Errorf("expected empty token for drained bag, got %q", tok)
@@ -610,13 +615,14 @@ func TestFinishPageNonEmptyBagYieldsSerializedState(t *testing.T) {
 		PendingSubs: []string{"sub-b", "sub-c"},
 	})
 
-	_, tok, _, err := finishPage(bag, nil)
+	_, res, err := finishPage(bag, nil)
 	if err != nil {
 		t.Fatalf("finishPage: %v", err)
 	}
-	if tok == "" {
+	if res == nil || res.NextPageToken == "" {
 		t.Fatalf("expected non-empty token, got empty")
 	}
+	tok := res.NextPageToken
 
 	restored, err := pagination.GenBagFromToken[raBagState](&pagination.Token{Token: tok})
 	if err != nil {
@@ -639,7 +645,7 @@ func TestListUnknownPhaseReturnsError(t *testing.T) {
 		t.Fatalf("Marshal: %v", err)
 	}
 	b := &roleAssignmentBuilder{}
-	_, _, _, err = b.List(context.Background(), nil, &pagination.Token{Token: tok})
+	_, _, err = b.List(context.Background(), nil, rs.SyncOpAttrs{PageToken: pagination.Token{Token: tok}})
 	if err == nil {
 		t.Fatalf("expected error on unknown phase, got nil")
 	}
@@ -800,7 +806,7 @@ func TestListFirstCallAcceptsEmptyToken(t *testing.T) {
 			return
 		}
 	}()
-	_, _, _, err := b.List(context.Background(), nil, &pagination.Token{Token: ""})
+	_, _, err := b.List(context.Background(), nil, rs.SyncOpAttrs{PageToken: pagination.Token{Token: ""}})
 	// If no panic, we must at least have a non-pagination error.
 	if err != nil && contains(err.Error(), "pagination") {
 		t.Errorf("empty token should be accepted by pagination layer; got %v", err)
@@ -840,14 +846,14 @@ func TestListSubPage_PreservesSeenSetAcrossSubTransition(t *testing.T) {
 	bag := &pagination.GenBag[raBagState]{}
 	b := &roleAssignmentBuilder{}
 
-	emitted, tok, _, err := b.listSubPage(context.Background(), zap.NewNop(), bag, state)
+	emitted, res, err := b.listSubPage(context.Background(), zap.NewNop(), bag, state)
 	if err != nil {
 		t.Fatalf("listSubPage: %v", err)
 	}
 	if len(emitted) != 0 {
 		t.Errorf("expected no resources emitted when CurrentSub empty, got %d", len(emitted))
 	}
-	if tok == "" {
+	if res == nil || res.NextPageToken == "" {
 		t.Fatalf("expected non-empty token — bag should still have pending subs to process")
 	}
 

--- a/pkg/connector/storage_account.go
+++ b/pkg/connector/storage_account.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/conductorone/baton-azure-infrastructure/pkg/connector/rolemapper"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -32,13 +31,13 @@ func (usr *storageAccountBuilder) ResourceType(ctx context.Context) *v2.Resource
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
-func (usr *storageAccountBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (usr *storageAccountBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
 	if parentResourceID.ResourceType != subscriptionsResourceType.Id {
-		return nil, "", nil, fmt.Errorf("parentResourceID.ResourceType is not supported: %s", parentResourceID.ResourceType)
+		return nil, nil, fmt.Errorf("parentResourceID.ResourceType is not supported: %s", parentResourceID.ResourceType)
 	}
 
 	factory, err := armstorage.NewClientFactory(
@@ -48,7 +47,7 @@ func (usr *storageAccountBuilder) List(ctx context.Context, parentResourceID *v2
 	)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	storageClient := factory.NewAccountsClient()
@@ -60,7 +59,7 @@ func (usr *storageAccountBuilder) List(ctx context.Context, parentResourceID *v2
 	for storageAccounts.More() {
 		response, err := storageAccounts.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		convertErr, err := ConvertErr(response.Value, func(account *armstorage.Account) (*v2.Resource, error) {
@@ -68,17 +67,17 @@ func (usr *storageAccountBuilder) List(ctx context.Context, parentResourceID *v2
 		})
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		resources = append(resources, convertErr...)
 	}
 
-	return resources, "", nil, nil
+	return resources, nil, nil
 }
 
 // Entitlements always returns an empty slice for users.
-func (usr *storageAccountBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (usr *storageAccountBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	rv := []*v2.Entitlement{
 		entitlement.NewPermissionEntitlement(
 			resource,
@@ -111,11 +110,11 @@ func (usr *storageAccountBuilder) Entitlements(_ context.Context, resource *v2.R
 		rv = append(rv, ent)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	type bagState struct {
 		Value    string `json:"value"`
 		State    string `json:"state"`
@@ -127,14 +126,14 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 	// Stores RoleDefinitionIds
 	bag := pagination.GenBag[bagState]{}
 
-	err := bag.Unmarshal(pToken.Token)
+	err := bag.Unmarshal(opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	storageResourceIDs, err := newStorageResourceSplitIdDataFromConnectorId(resource.Id.Resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	if bag.Current() == nil {
@@ -149,7 +148,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 			usr.conn.client.ArmOptions(),
 		)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		var grants []*v2.Grant
@@ -159,7 +158,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		for rolesAssignments.More() {
 			result, err := rolesAssignments.NextPage(ctx)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			convertErr, err := ConvertErr(result.Value, func(in *armauthorization.RoleAssignment) (*v2.Grant, error) {
@@ -172,7 +171,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 			})
 
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			grants = append(grants, convertErr...)
@@ -180,10 +179,10 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 
 		nextToken, err := bag.Marshal()
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		return grants, nextToken, nil, nil
+		return grants, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 	}
 
 	// Get the current state
@@ -197,18 +196,18 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		roleDefinition, err := usr.conn.roleDefinitionsClient.GetByID(ctx, roleDefinitionId, nil)
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		actions, err := rolemapper.StorageAccountPermissions.MapRoleToAzureRoleAction(roleDefinition.Properties.Permissions)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		for _, action := range actions {
 			plainRoleId, err := roleIdFromRoleDefinitionId(roleDefinitionId)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			roleResourceId, err := rs.NewResourceID(
@@ -217,12 +216,12 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 			)
 
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			newGrant, err := grantFromRole(resource, action, roleResourceId)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			grants = append(grants, newGrant)
@@ -231,7 +230,7 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 	case "ELIGIBLE":
 		if usr.conn.skipEntraIDP2LicenseFeatures {
 			l.Debug("skipping privileged access grants on storage accounts.")
-			return nil, "", nil, nil
+			return nil, nil, nil
 		}
 
 		privilegedId := state.Value
@@ -240,19 +239,19 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 			if err != nil {
 				if status.Code(err) == codes.NotFound {
 					l.Warn("Privileged access not found", zap.String("scope", storageResourceIDs.AzureId()))
-					return nil, "", nil, nil
+					return nil, nil, nil
 				}
 
 				if status.Code(err) == codes.PermissionDenied {
 					l.Error("Permission denied for get privileged access", zap.String("scope", storageResourceIDs.AzureId()))
-					return nil, "", nil, nil
+					return nil, nil, nil
 				}
 
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			if privilegedAccess == nil {
-				return nil, "", nil, fmt.Errorf("privileged access not found for scope %s", storageResourceIDs.AzureId())
+				return nil, nil, fmt.Errorf("privileged access not found for scope %s", storageResourceIDs.AzureId())
 			}
 
 			privilegedId = privilegedAccess.Id
@@ -262,17 +261,17 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		if err != nil {
 			if status.Code(err) == codes.PermissionDenied {
 				l.Error("Permission denied for get privileged access roles", zap.String("scope", privilegedId))
-				return nil, "", nil, nil
+				return nil, nil, nil
 			}
 
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		grantsResponse, err := ConvertErr(privilegedAssignments, func(in client.PMIRoleAssigment) (*v2.Grant, error) {
 			return grantFromEligibleAssignment(ctx, resource, in)
 		})
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		if nextLink != "" {
@@ -286,15 +285,15 @@ func (usr *storageAccountBuilder) Grants(ctx context.Context, resource *v2.Resou
 		grants = append(grants, grantsResponse...)
 
 	default:
-		return nil, "", nil, fmt.Errorf("unknown state: %s", state.State)
+		return nil, nil, fmt.Errorf("unknown state: %s", state.State)
 	}
 
 	nextToken, err := bag.Marshal()
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	return grants, nextToken, nil, nil
+	return grants, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 func newStorageAccountBuilder(conn *Connector) *storageAccountBuilder {

--- a/pkg/connector/subscription.go
+++ b/pkg/connector/subscription.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type subscriptionBuilder struct {
@@ -18,7 +17,7 @@ func (s *subscriptionBuilder) ResourceType(ctx context.Context) *v2.ResourceType
 	return subscriptionsResourceType
 }
 
-func (s *subscriptionBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (s *subscriptionBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var rv []*v2.Resource
 	// Load tenant hierarchy once so each emitted subscription points at its
 	// containing mgmt group as its parentResourceId. Degrades to disconnected
@@ -28,23 +27,23 @@ func (s *subscriptionBuilder) List(ctx context.Context, parentResourceID *v2.Res
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		for _, subscription := range page.Value {
 			sr, err := subscriptionResource(ctx, subscription, idx)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			rv = append(rv, sr)
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (s *subscriptionBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (s *subscriptionBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 	options := []ent.EntitlementOption{
 		ent.WithDisplayName(fmt.Sprintf("%s Subscription Owner", resource.DisplayName)),
@@ -60,11 +59,11 @@ func (s *subscriptionBuilder) Entitlements(_ context.Context, resource *v2.Resou
 	}
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, typeMembers, options...))
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (s *subscriptionBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (s *subscriptionBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newSubscriptionBuilder(conn *Connector) *subscriptionBuilder {

--- a/pkg/connector/tenant.go
+++ b/pkg/connector/tenant.go
@@ -4,8 +4,7 @@ import (
 	"context"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type tenantBuilder struct {
@@ -16,34 +15,34 @@ func (t *tenantBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return tenantResourceType
 }
 
-func (t *tenantBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (t *tenantBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var rv []*v2.Resource
 	pager := t.conn.clientFactory.NewTenantsClient().NewListPager(nil)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		for _, tenant := range page.Value {
 			sr, err := tenantResource(ctx, tenant)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			rv = append(rv, sr)
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (t *tenantBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (t *tenantBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
-func (t *tenantBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (t *tenantBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newTenantBuilder(conn *Connector) *tenantBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -11,9 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
-	resource "github.com/conductorone/baton-sdk/pkg/types/resource"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type userBuilder struct {
@@ -27,10 +25,10 @@ func (usr *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
-func (usr *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	resp, err := usr.client.Users(ctx, pToken.Token)
+func (usr *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	resp, err := usr.client.Users(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// If mailboxSettings is disabled, we can return the users without checking mailboxSettings.
@@ -39,10 +37,10 @@ func (usr *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 			return userResource(ctx, user, parentResourceID)
 		})
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		return users, resp.NextLink, nil, nil
+		return users, &rs.SyncOpResults{NextPageToken: resp.NextLink}, nil
 	}
 
 	var userResources []*v2.Resource
@@ -56,35 +54,35 @@ func (usr *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 				l.Debug("UserMailboxSetting: user not found", zap.String("user_id", ur.ID), zap.Error(err))
 				continue
 			}
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		userPurpose := strings.ToLower(mailboxSettingsResp.UserPurpose)
-		userAccountType := resource.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_HUMAN)
+		userAccountType := rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_HUMAN)
 		switch userPurpose {
 		case "room", "equipment", "shared":
-			userAccountType = resource.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE)
+			userAccountType = rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE)
 		}
 
 		userResource, err := userResource(ctx, ur, parentResourceID, userAccountType)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		userResources = append(userResources, userResource)
 	}
 
-	return userResources, resp.NextLink, nil, nil
+	return userResources, &rs.SyncOpResults{NextPageToken: resp.NextLink}, nil
 }
 
 // Entitlements always returns an empty slice for users.
-func (usr *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (usr *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (usr *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (usr *userBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(conn *Connector) *userBuilder {


### PR DESCRIPTION
## Summary

Mechanical signature migration across all 12 resource builders (user, group, managed_identity, subscription, tenant, resource_group, enterprise_applications, role, storage_account, role_assignment, management_group, container) from the baton-sdk V1 `ResourceSyncer` interface to V2 (`ResourceSyncerV2`). Preserves behavior exactly — no logic change, all in-process caches retained.

**Prerequisite for the containerization refactor (#TBD):** the SDK only exposes `opts.Session` to builders via the V2 `SyncOpAttrs` parameter. V2 upgrade is required before session-store migration.

## What changes

Per `baton-sdk/pkg/connectorbuilder/resource_syncer.go:52-61`:

\`\`\`go
// V1 (before)
List(ctx, parentResourceID, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error)

// V2 (after)
List(ctx, parentResourceID, opts resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error)
\`\`\`

- Signature change for `List` / `Entitlements` / `Grants` across all builders.
- `Connector.ResourceSyncers()` return type switches to `[]connectorbuilder.ResourceSyncerV2`.
- `main.go`: `WithDefaultCapabilitiesConnectorBuilder` → `WithDefaultCapabilitiesConnectorBuilderV2`.
- Tests updated to use the new signatures; `finishPage` helper returns `*SyncOpResults`.
- **Unchanged:** Grant/Revoke signatures (V1 `ResourceProvisioner`; SDK auto-adapts via `newResourceProvisionerV1to2`); all sync logic, pagination state machines, error handling.

## Stacked PR series

This PR stacks on top of #79. Merging order:
1. #79 (OptInRequired refactor + existing consolidation work)
2. **this PR** — V2 interface upgrade
3. Follow-up PR (TBD) — containerization + session-store migration

## Verification

- `gofmt` + `go vet` + `golangci-lint` + `go test ./...`: all green.
- Live lab sync (paired-with-entra shape, 9 resource types): counts consistent with baseline modulo lab state drift (+1 subscription, +1 mgmt group, +3 role assignments since 2026-04-20 baseline).
- Entitlement / grant / resource structure preserved; the count differences track exactly with the extra subscription (role definitions 881→1754 ≈ 881×2, subscription 1→2, etc).

## Test plan

- [ ] CI green (`verify.yaml` / `generate-baton-metadata.yaml`)
- [ ] Reviewer spot-checks a few builder signatures for the V1→V2 pattern consistency
- [ ] No behavioral drift in the emitted c1z vs the pre-V2 output (other than documented lab state drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)