### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up a Microsoft Azure Infrastructure connector"
+title: "Set up a Microsoft Azure Infrastructure connector"
 description: "C1 provides identity governance and just-in-time provisioning for Microsoft Azure Infrastructure. Integrate your Azure Infrastructure instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title:"Set up a Microsoft Azure Infrastructure connector"
+og:title: "Set up a Microsoft Azure Infrastructure connector"
 og:description: "C1 provides identity governance and just-in-time provisioning for Microsoft Azure Infrastructure. Integrate your Azure Infrastructure instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Microsoft Azure Infrastructure"
 ---

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up an Azure Infrastructure connector"
+title:"Set up a Microsoft Azure Infrastructure connector"
 description: "C1 provides identity governance and just-in-time provisioning for Microsoft Azure Infrastructure. Integrate your Azure Infrastructure instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title: "Set up an Azure Infrastructure connector"
+og:title:"Set up a Microsoft Azure Infrastructure connector"
 og:description: "C1 provides identity governance and just-in-time provisioning for Microsoft Azure Infrastructure. Integrate your Azure Infrastructure instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Microsoft Azure Infrastructure"
 ---
@@ -138,7 +138,7 @@ A user with at least the **Cloud Application Administrator** permission in Azure
 - To provision subscription roles: The **Owner** role is required to provision access to other roles in the subscription.
 </Warning>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Azure Infrastructure connector
 
@@ -222,7 +222,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Azure Infrastructure connector is now pulling access data into C1.
+**Done.** Your Azure Infrastructure connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -359,7 +359,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Azure Infrastructure connector is now pulling access data into C1.
+**Done.** Your Azure Infrastructure connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`