### PR TITLE
fix: mark azure-client-secret as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var Config = field.NewConfiguration(
 		field.StringField(
 			"azure-client-secret",
 			field.WithDescription("Azure Client Secret"),
+			field.WithIsSecret(true),
 		),
 		field.StringField(
 			"azure-tenant-id",


### PR DESCRIPTION
The `azure-client-secret` config field carries the Azure service-principal
client secret but was defined as a plain `field.StringField` with no
`field.WithIsSecret(true)`, so it was not marked secret in the connector's
generated config schema. This adds `WithIsSecret(true)` to that field.

The other credential-adjacent fields (azure-tenant-id, azure-client-id) are
identifiers, not secrets, and are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

_Built with stargate._
